### PR TITLE
Show click counts per search query

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -73,8 +73,16 @@ MongoClient.connect(mongoUrl)
       }
 
       try {
-        const count = await collection.countDocuments(query);
-        res.json({ count });
+        const docs = await collection
+          .aggregate([
+            { $match: query },
+            { $group: { _id: '$ask', count: { $sum: 1 } } },
+            { $sort: { _id: 1 } },
+          ])
+          .toArray();
+
+        const results = docs.map(d => ({ ask: d._id, count: d.count }));
+        res.json({ results });
       } catch (err) {
         console.error('❌ Ошибка при подсчёте:', err);
         res.status(500).json({ error: 'Ошибка при подсчёте' });

--- a/front/app/filters/by-ask/page.tsx
+++ b/front/app/filters/by-ask/page.tsx
@@ -7,7 +7,7 @@ export default function ByAskPage() {
   const [ask, setAsk] = useState('');
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
-  const [count, setCount] = useState<number | null>(null);
+  const [results, setResults] = useState<{ ask: string; count: number }[] | null>(null);
 
   const handleSubmit = async () => {
     if (!ask && !from && !to) return;
@@ -20,10 +20,10 @@ export default function ByAskPage() {
           to: to ? new Date(to).getTime() : undefined,
         },
       });
-      setCount(res.data.count);
+      setResults(res.data.results);
     } catch (err) {
       console.error(err);
-      setCount(null);
+      setResults(null);
     }
   };
 
@@ -63,10 +63,14 @@ export default function ByAskPage() {
         </button>
       </div>
 
-      {count !== null && (
-        <div className="text-lg font-semibold">
-          Количество кликов: <span className="text-blue-600">{count}</span>
-        </div>
+      {results && (
+        <ul className="text-lg font-semibold space-y-1">
+          {results.map(({ ask, count }) => (
+            <li key={ask}>
+              {ask} - <span className="text-blue-600">{count}</span>
+            </li>
+          ))}
+        </ul>
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- group `/api/clicks` results by search term and return individual click totals
- list each matching query with its click count on the ByAsk page

## Testing
- `npm test` (front) – missing script
- `npm run lint`
- `npm test` (backend) – missing script
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_e_6895b0b5d4d8833296d410c1c5caf928