### PR TITLE
Trim whitespace in search queries

### DIFF
--- a/front/app/filters/by-ask/page.tsx
+++ b/front/app/filters/by-ask/page.tsx
@@ -10,12 +10,13 @@ export default function ByAskPage() {
   const [results, setResults] = useState<{ ask: string; count: number }[] | null>(null);
 
   const handleSubmit = async () => {
-    if (!ask && !from && !to) return;
+    const trimmedAsk = ask.trim();
+    if (!trimmedAsk && !from && !to) return;
 
     try {
       const res = await axios.get('http://localhost:3000/api/clicks', {
         params: {
-          ask,
+          ask: trimmedAsk,
           from: from ? new Date(from).getTime() : undefined,
           to: to ? new Date(to).getTime() : undefined,
         },


### PR DESCRIPTION
## Summary
- Trim leading and trailing spaces from search query before requesting analytics results

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895b48b86f0833290ff10f2ace11202