### PR TITLE
Add Dockerfile and compose entry for frontend

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -27,3 +27,11 @@ services:
       - 3000:3000
     depends_on:
       - db
+
+  front:
+    build: ./front
+    image: front
+    ports:
+      - 3001:3001
+    depends_on:
+      - backend

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+EXPOSE 3001
+CMD ["npm","start"]


### PR DESCRIPTION
## Summary
- add Dockerfile for Next.js frontend
- wire frontend service into compose config

## Testing
- `npm run lint`
- `npm run build`
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_6895c1ade8988332be996f670357910e